### PR TITLE
Remove environment variable STRACE2DS

### DIFF
--- a/strace2ds-library/DataSeriesOutputModule.cpp
+++ b/strace2ds-library/DataSeriesOutputModule.cpp
@@ -342,8 +342,13 @@ void DataSeriesOutputModule::initArgsMapFuncPtr() {
 * number
 */
 void DataSeriesOutputModule::initSyscallNameNumberMap() {
-  const char *env_path = getenv("STRACE2DS");
-  if (!env_path) env_path = "/usr/local/strace2ds";
+  // TODO: Find a way to find the libraries relative to the executable.
+  // The current way searches a path relative to the user's current directory.
+  const char *env_path = "../lib/strace2ds";
+  struct stat relative_lib_info;
+  int lib_search_return = stat(env_path, &relative_lib_info);
+  if (lib_search_return != 0 || !(S_ISDIR(relative_lib_info.st_mode)))
+    env_path = "/usr/local/strace2ds";
   std::string file_path =
       std::string(env_path) + "/" + "tables/syscalls_name_number.table";
 


### PR DESCRIPTION
When a user installs this library in a directory other than
/usr/local/strace2ds, we still need to find the xml and table files.
Previously, we relied on the user setting an environment variable that
contained the path where strace2ds was installed. Now, we check for the
files with the relative path ../lib/strace2ds. This needs to be made
more robust, while still avoiding a kludgy environment variable.