### PR TITLE
Polishing Changes (Reanimator-Library)

### DIFF
--- a/build-reanimator-library.sh
+++ b/build-reanimator-library.sh
@@ -81,7 +81,6 @@ if $install; then
 fi
 
 # Set up the build directory
-runcmd /bin/rm -rf "${buildDir}"
 runcmd mkdir -p "${buildDir}"
 runcmd mkdir -p xml
 runcmd cd tables

--- a/src/strace2ds.cpp
+++ b/src/strace2ds.cpp
@@ -159,7 +159,7 @@ void ds_add_to_untraced_set(DataSeriesOutputModule *ds_module,
            ->untraced_sys_call_counts_[sys_call_number]) {
     ((DataSeriesOutputModule *)ds_module)
         ->untraced_sys_call_counts_[sys_call_number] = 1;
-    std::cerr << "WARNING: Ignoring to replay system call: " << sys_call_name
+    std::cerr << "WARNING: Ignoring system call: " << sys_call_name
               << " (" << sys_call_number << ")" << std::endl;
   } else {
     ((DataSeriesOutputModule *)ds_module)


### PR DESCRIPTION
Summary of changes:

- No longer blowing away `build/` directory and completely recompiling every time `build-reanimator-library.sh` is run
- Update ignored syscall warning to `WARNING: Ignoring system call`